### PR TITLE
Фикс установки mihomo: убрана зависимость от gh CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,14 +123,16 @@ jobs:
           ls -l output/dat/*.dat
 
       - name: Install Mihomo (latest stable .deb)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          gh release download -R MetaCubeX/mihomo --pattern 'mihomo-linux-amd64*.deb' --dir /tmp
-          sudo apt-get install -y "$(ls -1 /tmp/mihomo-linux-amd64*.deb | head -n1)"
-          rm -f /tmp/mihomo-linux-amd64*.deb
+          ARCH=$(dpkg --print-architecture)
+          LATEST_URL=$(${{ env.CURL }} https://api.github.com/repos/MetaCubeX/mihomo/releases/latest \
+            | grep -oP '"browser_download_url":\s*"\K[^"]*mihomo-linux-'"$ARCH"'-[^"]*\.deb(?=")' \
+            | head -n1)
+          echo "Downloading: $LATEST_URL"
+          ${{ env.CURL }} -o /tmp/mihomo.deb "$LATEST_URL"
+          sudo dpkg -i /tmp/mihomo.deb || sudo apt-get install -f -y
+          rm -f /tmp/mihomo.deb
 
       - name: Install sing-box
         env:


### PR DESCRIPTION
## Суть

Замена `gh release download` на прямой `curl` к GitHub API для скачивания mihomo `.deb`.

## Проблема

Шаг "Install Mihomo" использует `gh release download`, но `gh` CLI может отсутствовать в некоторых runner-окружениях (например, custom runners, act). Кроме того, скачивался всегда `amd64` пакет без учёта архитектуры runner'а.

## Что изменено

- `gh release download` → `curl` к `api.github.com/repos/MetaCubeX/mihomo/releases/latest`
- Добавлено автоопределение архитектуры через `dpkg --print-architecture`
- Работает на amd64 и arm64 без зависимости от `gh` CLI
- Убраны лишние env-переменные `GITHUB_TOKEN`/`GH_TOKEN` (публичный репозиторий, API без авторизации)

## Тестирование

Протестировано локально через `act push` на arm64. Mihomo устанавливается корректно.